### PR TITLE
.Zip'ped binary for Win users

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Binary distribution
 
 To get a precompiled binary for jNeuroML, either:
 
-   [Download .ZIP from GitHub Repository](releases/download/v0.7.1/jnml-0.7.1.zip). Then extract to a folder.
+   [Download .ZIP from GitHub Repository](../releases/download/v0.7.1/jnml-0.7.1.zip). Then extract to a folder.
    
 or type:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Binary distribution
 
 To get a precompiled binary for jNeuroML, either:
 
-   [Download from GitHub Repository](bin/jnml-0.7.1.zip)
+   [Download .ZIP from GitHub Repository](../../raw/master/bin/jnml-0.7.1.zip). Then extract to a folder.
 
 or type:
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Binary distribution
 
 To get a precompiled binary for jNeuroML, either:
 
-   [Download .ZIP from GitHub Repository](../../raw/master/bin/jnml-0.7.1.zip). Then extract to a folder.
-
+   [Download .ZIP from GitHub Repository](releases/download/v0.7.1/jnml-0.7.1.zip). Then extract to a folder.
+   
 or type:
 
     svn checkout svn://svn.code.sf.net/p/neuroml/code/jNeuroMLJar

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ JNeuroML can:
 Binary distribution
 -------------------
 
-To get a precompiled binary for jNeuroML, type:
+To get a precompiled binary for jNeuroML, either:
+
+   [Download from GitHub Repository](bin/jnml-0.7.1.zip)
+
+or type:
 
     svn checkout svn://svn.code.sf.net/p/neuroml/code/jNeuroMLJar
     cd jNeuroMLJar

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Binary distribution
 
 To get a precompiled binary for jNeuroML, either:
 
-   [Download .ZIP from GitHub Repository](../releases/download/v0.7.1/jnml-0.7.1.zip). Then extract to a folder.
+   [Download .ZIP from GitHub Repository](../../releases/download/v0.7.1/jnml-0.7.1.zip). Then extract to a folder.
    
 or type:
 


### PR DESCRIPTION
So they don't need to install SVN (to get jnml) to run a NeuroML/LEMS model.