### PR TITLE
self explanatory minor changes for forwards compliance to python3

### DIFF
--- a/getNeuroML.py
+++ b/getNeuroML.py
@@ -113,12 +113,16 @@ def main():
                 command = "mvn install"
                 print("It's a Java repository, so installing using Maven...")
                 info = execute_command_in_dir(command, local_dir)
-                if str("BUILD SUCCESS") in info:
-                    print("Successful installation using : %s!" %command)
-                else:
-                    print("Problem installing using : %s!" %command)
-                    print(info)
-                    exit(1)
+                
+                #The code below needs a non trivial rewrite due to python3 differences.
+
+                #                
+                #if str("BUILD SUCCESS") in info:
+                #    print("Successful installation using : %s!" %command)
+                #else:
+                #    print("Problem installing using : %s!" %command)
+                #    print(info)
+                #    exit(1)
 
     if mode is "update":
         print("All repositories successfully updated & Java modules built!")

--- a/getNeuroML.py
+++ b/getNeuroML.py
@@ -113,7 +113,7 @@ def main():
                 command = "mvn install"
                 print("It's a Java repository, so installing using Maven...")
                 info = execute_command_in_dir(command, local_dir)
-                if "BUILD SUCCESS" in info:
+                if str("BUILD SUCCESS") in info:
                     print("Successful installation using : %s!" %command)
                 else:
                     print("Problem installing using : %s!" %command)

--- a/getNeuroML.py
+++ b/getNeuroML.py
@@ -16,7 +16,7 @@ def main():
     if len(sys.argv) < 5:
         for arg in sys.argv[1:]:
             if arg == "clean":
-                print "Cleaning repos"
+                print("Cleaning repos")
                 mode = "clean"
             elif arg == "development":
                 switch_to_branch = "development"
@@ -72,37 +72,35 @@ def main():
         local_dir = ".." + os.sep + repo.split("/")[1]
 
         if mode is "clean":
-            print "------ Cleaning: %s -------" % repo
+            print("------ Cleaning: %s -------"%repo)
             if repo in java_repos:
                 command = "mvn clean"
-                print "It's a Java repository, so cleaning using Maven..."
+                print("It's a Java repository, so cleaning using Maven...")
                 info = execute_command_in_dir(command, local_dir)
 
         if mode is "update":
 
-            print
-            print "------ Updating: %s -------" % repo
+            print("------ Updating: %s -------" %repo)
 
             runMvnInstall = False
 
             if not op.isdir(local_dir):
                 command = "git clone %s%s" % (pre_gh[github_pref], repo)
-                print "Creating a new directory: %s by cloning from GitHub" % \
-                    (local_dir)
+                print("Creating a new directory: %s by cloning from GitHub" %(local_dir))
                 execute_command_in_dir(command, "..")
                 
                 runMvnInstall = True
 
             if switch_to_branch:
                 if (repo in dev_branch_repos):
-                    command = "git checkout %s" % (switch_to_branch)
-                    print "Switching to branch: %s" % (switch_to_branch)
+                    command = "git checkout %s" %(switch_to_branch)
+                    print("Switching to branch: %s" %(switch_to_branch))
                     exit_on_fail = switch_to_branch is not "experimental"
                     execute_command_in_dir(command, local_dir, exit_on_fail)
                     runMvnInstall = True
 
             info = execute_command_in_dir("git branch", local_dir)
-            print info.strip()
+            print(info.strip())
 
             return_string = execute_command_in_dir("git pull", local_dir)
 
@@ -113,40 +111,31 @@ def main():
 
             if (repo in java_repos or repo in neuroml2_spec_repo) and runMvnInstall:
                 command = "mvn install"
-                print "It's a Java repository, so installing using Maven..."
+                print("It's a Java repository, so installing using Maven...")
                 info = execute_command_in_dir(command, local_dir)
                 if "BUILD SUCCESS" in info:
-                    print "Successful installation using : %s!" % command
+                    print("Successful installation using : %s!" %command)
                 else:
-                    print "Problem installing using : %s!" % command
-                    print info
+                    print("Problem installing using : %s!" %command)
+                    print(info)
                     exit(1)
 
     if mode is "update":
-        print
-        print "All repositories successfully updated & Java modules built!"
-        print
-        print "You should be able to run some examples straight " \
-              "away using jnml: "
-        print
+        print("All repositories successfully updated & Java modules built!")
+        print("You should be able to run some examples straight " \
+              "away using jnml: ")
         if os.name is not 'nt':
-            print "  ./jnml "\
-                "-validate ../NeuroML2/examples/NML2_FullNeuroML.nml"
-            print
-            print "  ./jnml " \
-                "../NeuroML2/LEMSexamples/LEMS_NML2_Ex2_Izh.xml"
+            print("  ./jnml "\
+                "-validate ../NeuroML2/examples/NML2_FullNeuroML.nml")
+            print("  ./jnml " \
+                "../NeuroML2/LEMSexamples/LEMS_NML2_Ex2_Izh.xml")
         else:
-            print "  jnml -validate " \
-                "..\\NeuroML2\\examples\\NML2_FullNeuroML.nml"
-            print
-            print "  jnml " \
-                "..\\NeuroML2\\LEMSexamples\\LEMS_NML2_Ex2_Izh.xml"
-        print
-
+            print("  jnml -validate " \
+                "..\\NeuroML2\\examples\\NML2_FullNeuroML.nml")
+            print("  jnml " \
+                "..\\NeuroML2\\LEMSexamples\\LEMS_NML2_Ex2_Izh.xml")
     if mode is "clean":
-        print
-        print "All repositories successfully cleaned!"
-        print
+        print("All repositories successfully cleaned!")
 
 
 
@@ -155,27 +144,27 @@ def execute_command_in_dir(command, directory, exit_on_fail=True):
     """Execute a command in specific working directory"""
     if os.name == 'nt':
         directory = os.path.normpath(directory)
-    print ">>>  Executing: (%s) in dir: %s" % (command, directory)
+    print(">>>  Executing: (%s) in dir: %s" %(command, directory))
     p = subprocess.Popen(command, cwd=directory, shell=True, stdout=subprocess.PIPE)
     return_str = p.communicate()
      
     if p.returncode != 0:                           
-        print "Error: %s" % p.returncode
+        print("Error: %s" %p.returncode)
         if exit_on_fail: 
             exit(p.returncode)
     return return_str[0]
 
 
 def help_info():
-    print "\nUsage:\n\n    python getNeuroML.py\n        " \
+    print("\nUsage:\n\n    python getNeuroML.py\n        " \
     "Pull (or clone) the latest version of all NeuroML 2 repos & " \
     "compile/install with Maven if applicable\n\n" \
-    "    python getNeuroML.py clean\n        " \
+    "    python getNeuroML.py clean\n        " 
     "Run 'mvn clean' on all Java repos\n\n" \
     "    python getNeuroML.py master\n       " \
     "Switch all repos to master branch\n\n" \
     "    python getNeuroML.py development\n       " \
-        "Switch relevant repos to development branch\n\n"
+        "Switch relevant repos to development branch\n\n")
 
 
 if __name__ == "__main__":

--- a/getNeuroML.py
+++ b/getNeuroML.py
@@ -14,19 +14,19 @@ def main():
     switch_to_branch = None
     
     if len(sys.argv) < 5:
-    	for arg in sys.argv[1:]:
+        for arg in sys.argv[1:]:
             if arg == "clean":
-    	    	print "Cleaning repos"
-    	    	mode = "clean"
-    	    elif arg == "development":
+                print "Cleaning repos"
+                mode = "clean"
+            elif arg == "development":
                 switch_to_branch = "development"
-    	    elif arg == "experimental":
+            elif arg == "experimental":
                 switch_to_branch = "experimental"
-    	    elif arg == "master":
+            elif arg == "master":
                 switch_to_branch = "master"
             else:
-    	        help_info()
-    	        exit()
+                help_info()
+                exit()
     else:
         help_info()
         exit()
@@ -168,14 +168,14 @@ def execute_command_in_dir(command, directory, exit_on_fail=True):
 
 def help_info():
     print "\nUsage:\n\n    python getNeuroML.py\n        " \
-	"Pull (or clone) the latest version of all NeuroML 2 repos & " \
-	"compile/install with Maven if applicable\n\n" \
-	"    python getNeuroML.py clean\n        " \
-	"Run 'mvn clean' on all Java repos\n\n" \
-	"    python getNeuroML.py master\n       " \
-	"Switch all repos to master branch\n\n" \
-	"    python getNeuroML.py development\n       " \
-    	"Switch relevant repos to development branch\n\n"
+    "Pull (or clone) the latest version of all NeuroML 2 repos & " \
+    "compile/install with Maven if applicable\n\n" \
+    "    python getNeuroML.py clean\n        " \
+    "Run 'mvn clean' on all Java repos\n\n" \
+    "    python getNeuroML.py master\n       " \
+    "Switch all repos to master branch\n\n" \
+    "    python getNeuroML.py development\n       " \
+        "Switch relevant repos to development branch\n\n"
 
 
 if __name__ == "__main__":

--- a/getNeuroML.py
+++ b/getNeuroML.py
@@ -105,7 +105,7 @@ def main():
             return_string = execute_command_in_dir("git pull", local_dir)
 
             runMvnInstall = runMvnInstall \
-                or ("Already up-to-date" not in return_string) \
+                or ("Already up-to-date" not in str(return_string)) \
                 or not op.isdir(local_dir + os.sep + "target") \
                 or ("jNeuroML" in repo)
 
@@ -117,12 +117,12 @@ def main():
                 #The code below needs a non trivial rewrite due to python3 differences.
 
                 #                
-                #if str("BUILD SUCCESS") in info:
-                #    print("Successful installation using : %s!" %command)
-                #else:
-                #    print("Problem installing using : %s!" %command)
-                #    print(info)
-                #    exit(1)
+                if str("BUILD SUCCESS") in str(info):
+                    print("Successful installation using : %s!" %command)
+                else:
+                    print("Problem installing using : %s!" %command)
+                    print(info)
+                    exit(1)
 
     if mode is "update":
         print("All repositories successfully updated & Java modules built!")


### PR DESCRIPTION
Same as previous pull request, except noticed another py2/3 compatibility breach:
Idioms like this:
if "BUILD SUCCESS" in info  
Must explicitly be cast to string. I don't really understand why but it seems to work.
if "BUILD SUCCESS" in str(info)
