### PR TITLE
Python 3 compatible getneuroML file

### DIFF
--- a/getNeuroML.py
+++ b/getNeuroML.py
@@ -14,19 +14,19 @@ def main():
     switch_to_branch = None
     
     if len(sys.argv) < 5:
-    	for arg in sys.argv[1:]:
+        for arg in sys.argv[1:]:
             if arg == "clean":
-    	    	print "Cleaning repos"
-    	    	mode = "clean"
-    	    elif arg == "development":
+                print ("Cleaning repos")
+                mode = "clean"
+            elif arg == "development":
                 switch_to_branch = "development"
-    	    elif arg == "experimental":
+            elif arg == "experimental":
                 switch_to_branch = "experimental"
-    	    elif arg == "master":
+            elif arg == "master":
                 switch_to_branch = "master"
             else:
-    	        help_info()
-    	        exit()
+                help_info()
+                exit()
     else:
         help_info()
         exit()

--- a/getNeuroML.py
+++ b/getNeuroML.py
@@ -1,5 +1,5 @@
 """Script to handle the NeuroML 2 repos"""
-
+from __future__ import print_function
 import os
 import sys
 import os.path as op
@@ -72,23 +72,21 @@ def main():
         local_dir = ".." + os.sep + repo.split("/")[1]
 
         if mode is "clean":
-            print "------ Cleaning: %s -------" % repo
+            print ("------ Cleaning: %s -------" % repo)
             if repo in java_repos:
                 command = "mvn clean"
-                print "It's a Java repository, so cleaning using Maven..."
+                print ("It's a Java repository, so cleaning using Maven...")
                 info = execute_command_in_dir(command, local_dir)
 
         if mode is "update":
-
-            print
-            print "------ Updating: %s -------" % repo
+            print ("------ Updating: %s -------" % repo)
 
             runMvnInstall = False
 
             if not op.isdir(local_dir):
                 command = "git clone %s%s" % (pre_gh[github_pref], repo)
-                print "Creating a new directory: %s by cloning from GitHub" % \
-                    (local_dir)
+                print ("Creating a new directory: %s by cloning from GitHub" % \
+                    (local_dir))
                 execute_command_in_dir(command, "..")
                 
                 runMvnInstall = True
@@ -96,57 +94,57 @@ def main():
             if switch_to_branch:
                 if (repo in dev_branch_repos):
                     command = "git checkout %s" % (switch_to_branch)
-                    print "Switching to branch: %s" % (switch_to_branch)
+                    print ("Switching to branch: %s" % (switch_to_branch))
                     exit_on_fail = switch_to_branch is not "experimental"
                     execute_command_in_dir(command, local_dir, exit_on_fail)
                     runMvnInstall = True
 
             info = execute_command_in_dir("git branch", local_dir)
-            print info.strip()
+            print (info.strip())
 
             return_string = execute_command_in_dir("git pull", local_dir)
 
             runMvnInstall = runMvnInstall \
-                or ("Already up-to-date" not in return_string) \
+                or b"Already up-to-date" not in return_string \
                 or not op.isdir(local_dir + os.sep + "target") \
                 or ("jNeuroML" in repo)
 
             if (repo in java_repos or repo in neuroml2_spec_repo) and runMvnInstall:
                 command = "mvn install"
-                print "It's a Java repository, so installing using Maven..."
+                print ("It's a Java repository, so installing using Maven...")
                 info = execute_command_in_dir(command, local_dir)
-                if "BUILD SUCCESS" in info:
-                    print "Successful installation using : %s!" % command
+                if b"BUILD SUCCESS" in info:
+                    print ("Successful installation using : %s!" % command)
                 else:
-                    print "Problem installing using : %s!" % command
-                    print info
+                    print ("Problem installing using : %s!" % command)
+                    print (info)
                     exit(1)
 
     if mode is "update":
-        print
-        print "All repositories successfully updated & Java modules built!"
-        print
-        print "You should be able to run some examples straight " \
-              "away using jnml: "
-        print
+        print()
+        print ("All repositories successfully updated & Java modules built!")
+        print()
+        print ("You should be able to run some examples straight " \
+              "away using jnml: ")
+        print()
         if os.name is not 'nt':
-            print "  ./jnml "\
-                "-validate ../NeuroML2/examples/NML2_FullNeuroML.nml"
-            print
-            print "  ./jnml " \
-                "../NeuroML2/LEMSexamples/LEMS_NML2_Ex2_Izh.xml"
+            print ("  ./jnml "\
+                "-validate ../NeuroML2/examples/NML2_FullNeuroML.nml")
+            print()
+            print ("  ./jnml " \
+                "../NeuroML2/LEMSexamples/LEMS_NML2_Ex2_Izh.xml")
         else:
-            print "  jnml -validate " \
-                "..\\NeuroML2\\examples\\NML2_FullNeuroML.nml"
-            print
-            print "  jnml " \
-                "..\\NeuroML2\\LEMSexamples\\LEMS_NML2_Ex2_Izh.xml"
-        print
+            print ("  jnml -validate " \
+                "..\\NeuroML2\\examples\\NML2_FullNeuroML.nml")
+            print()
+            print ("  jnml " \
+                "..\\NeuroML2\\LEMSexamples\\LEMS_NML2_Ex2_Izh.xml")
+        print()
 
     if mode is "clean":
-        print
-        print "All repositories successfully cleaned!"
-        print
+        print()
+        print ("All repositories successfully cleaned!")
+        print()
 
 
 
@@ -155,19 +153,19 @@ def execute_command_in_dir(command, directory, exit_on_fail=True):
     """Execute a command in specific working directory"""
     if os.name == 'nt':
         directory = os.path.normpath(directory)
-    print ">>>  Executing: (%s) in dir: %s" % (command, directory)
+    print (">>>  Executing: (%s) in dir: %s" % (command, directory))
     p = subprocess.Popen(command, cwd=directory, shell=True, stdout=subprocess.PIPE)
     return_str = p.communicate()
      
     if p.returncode != 0:                           
-        print "Error: %s" % p.returncode
+        print ("Error: %s" % p.returncode)
         if exit_on_fail: 
             exit(p.returncode)
     return return_str[0]
 
 
 def help_info():
-    print "\nUsage:\n\n    python getNeuroML.py\n        " \
+    print ("\nUsage:\n\n    python getNeuroML.py\n        " \
 	"Pull (or clone) the latest version of all NeuroML 2 repos & " \
 	"compile/install with Maven if applicable\n\n" \
 	"    python getNeuroML.py clean\n        " \
@@ -175,7 +173,7 @@ def help_info():
 	"    python getNeuroML.py master\n       " \
 	"Switch all repos to master branch\n\n" \
 	"    python getNeuroML.py development\n       " \
-    	"Switch relevant repos to development branch\n\n"
+    "Switch relevant repos to development branch\n\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I was trying to setup jNeuroML from source in a python3 environment and getNeuroml.py file posed an issue as it is not python 3 compatible. Although its functionality is just to setup repos for jNeuroML which is still possible via python2, but it would be great if we don't have to switch python for using it. 
I changed few things to make it python 2+3 compatible.
* imported print from future
* removed unordered use of tabs and spaces for indentation
* resolved bytes for str error
There are multiple empty print statements that can be replaced by \n but I haven't changed to keep this PR minimal.

Also I noticed that setting up jNeuroML from source with java 9 throw error with `jdx` lib. As per my research we need to update the minimum ersion of this lib to 2.2, still there are other issues with java 9 compatibility.
It would be great if you can mention that  `use java 8 to build from source` on readme file. I can make a commit if you want.