### PR TITLE
Update getNeuroML.py

### DIFF
--- a/getNeuroML.py
+++ b/getNeuroML.py
@@ -103,7 +103,7 @@ def main():
             return_string = execute_command_in_dir("git pull", local_dir)
 
             runMvnInstall = runMvnInstall \
-                or b"Already up-to-date" not in return_string \
+                or "Already up-to-date" not in return_string \
                 or not op.isdir(local_dir + os.sep + "target") \
                 or ("jNeuroML" in repo)
 


### PR DESCRIPTION
Fixes for python3.6 for the following error.

```
TypeError: 'in <string>' requires string as left operand, not bytes
```
Not sure if it will break python2.