### PR TITLE
Check termination status of graphviz command

### DIFF
--- a/src/main/java/org/neuroml/JNeuroML.java
+++ b/src/main/java/org/neuroml/JNeuroML.java
@@ -896,15 +896,30 @@ public class JNeuroML
                     {
                         pr.waitFor();
 
-                        BufferedReader buf = new BufferedReader(new InputStreamReader(pr.getErrorStream()));
-                        String line;
-                        while((line = buf.readLine()) != null)
+                        /* Successful termination of command */
+                        if (pr.exitValue() == 0)
                         {
-                            System.out.println("----" + line);
+                            BufferedReader buf = new BufferedReader(new InputStreamReader(pr.getInputStream()));
+                            String line;
+                            while((line = buf.readLine()) != null)
+                            {
+                                System.out.println("----" + line);
+                            }
+                            System.out.println("Have successfully run command: " + cmd);
+                            System.exit(0);
                         }
-
-                        System.out.println("Have successfully run command: " + cmd);
-
+                        /* Unsuccessful termination of command */
+                        else
+                        {
+                            BufferedReader buf = new BufferedReader(new InputStreamReader(pr.getErrorStream()));
+                            String line;
+                            while((line = buf.readLine()) != null)
+                            {
+                                System.out.println("----" + line);
+                            }
+                            System.out.println("Error running command: " + cmd);
+                            System.exit(1);
+                        }
                     }
                     catch(InterruptedException e)
                     {


### PR DESCRIPTION
We now check the error code returned by the command before printing
"successfully ran..". If there's an error in the command, because of a
malformed dot file for example, we will print the stderr messages for
the user and clearly state that the command failed.

So, instead of this:

```
jnml LEMS_example-izhikevich2007network-sim.xml -graph
 jNeuroML v0.10.1
(INFO) Reading from: /home/asinha/Documents/02_Code/00_mine/2020-OSB/NeuroML-Documentation/source/Userdocs/NML2_examples/LEMS_example-izhikevich2007network-sim.xml
(INFO) simCpt: Component(id=example-izhikevich2007network-sim type=Simulation)
Writing to: /home/asinha/Documents/02_Code/00_mine/2020-OSB/NeuroML-Documentation/source/Userdocs/NML2_examples/LEMS_example-izhikevich2007network-sim.gv
----Error: /home/asinha/Documents/02_Code/00_mine/2020-OSB/NeuroML-Documentation/source/Userdocs/NML2_examples/LEMS_example-izhikevich2007network-sim.gv: syntax error in line 3 near '-'
Have successfully run command: dot -Tpng  /home/asinha/Documents/02_Code/00_mine/2020-OSB/NeuroML-Documentation/source/Userdocs/NML2_examples/LEMS_example-izhikevich2007network-sim.gv -o /home/asinha/Documents/02_Code/00_mine/2020-OSB/NeuroML-Documentation/source/Userdocs/NML2_examples/LEMS_example-izhikevich2007network-sim.png

```

we now get this:

```
jnml LEMS_example-izhikevich2007network-sim.xml -graph
 jNeuroML v0.10.1
(INFO) Reading from: /home/asinha/Documents/02_Code/00_mine/2020-OSB/NeuroML-Documentation/source/Userdocs/NML2_examples/LEMS_example-izhikevich2007network-sim.xml
(INFO) simCpt: Component(id=example-izhikevich2007network-sim type=Simulation)
Writing to: /home/asinha/Documents/02_Code/00_mine/2020-OSB/NeuroML-Documentation/source/Userdocs/NML2_examples/LEMS_example-izhikevich2007network-sim.gv
----Error: /home/asinha/Documents/02_Code/00_mine/2020-OSB/NeuroML-Documentation/source/Userdocs/NML2_examples/LEMS_example-izhikevich2007network-sim.gv: syntax error in line 3 near '-'
Error running command: dot -Tpng  /home/asinha/Documents/02_Code/00_mine/2020-OSB/NeuroML-Documentation/source/Userdocs/NML2_examples/LEMS_example-izhikevich2007network-sim.gv -o /home/asinha/Documents/02_Code/00_mine/2020-OSB/NeuroML-Documentation/source/Userdocs/NML2_examples/LEMS_example-izhikevich2007network-sim.png

```