### PR TITLE
Add a `-lems-graph` option that mirrors the `-graph` option

### DIFF
--- a/src/main/java/org/neuroml/JNeuroML.java
+++ b/src/main/java/org/neuroml/JNeuroML.java
@@ -67,7 +67,7 @@ public class JNeuroML
 
     public static final String VERSION_FLAG = "-v";
     public static final String VERSION_FLAG_LONG = "-version";
-    
+
     public static final String SEARCH_PATH_FLAG = "-I";
     public static final String SEARCH_PATH_JLEMSLIKE_FLAG = "-cp";
 
@@ -76,7 +76,7 @@ public class JNeuroML
     public static final String RUN_FLAG = "-run";
 
     public static final String NO_RUN_FLAG = "-norun";
-    
+
     public static final String OUTPUT_DIR_FLAG = "-outputdir";
 
     public static final String VALIDATE_FLAG = "-validate";
@@ -111,11 +111,11 @@ public class JNeuroML
 
     public static final String PYNN_EXPORT_FLAG = "-pynn";
     public static final String RUN_PYNN_NEURON_FLAG = "-run-neuron";
-    
+
     public static final String NETPYNE_EXPORT_FLAG = "-netpyne";
-    
+
     public static final String NUMBER_PROCESSORS_FLAG = "-np";
-    
+
     public static final String VERTEX_EXPORT_FLAG = "-vertex";
 
     public static final String NINEML_EXPORT_FLAG = "-nineml";
@@ -124,7 +124,7 @@ public class JNeuroML
     public static final String NEST_EXPORT_FLAG = "-nest";
 
     public static final String MOOSE_EXPORT_FLAG = "-moose";
-    
+
     //public static final String GEPPETTO_EXPORT_FLAG = "-geppetto";
 
     public static final String SBML_IMPORT_FLAG = "-sbml-import";
@@ -132,7 +132,7 @@ public class JNeuroML
     public static final String SBML_EXPORT_FLAG = "-sbml";
     public static final String SBML_SEDML_EXPORT_FLAG = "-sbml-sedml";
 
-    public static final String GRAPH_FLAG = "-graph";
+    public static final String OLD_GRAPH_FLAG = "-graph";
     public static final String LEMS_GRAPH_FLAG = "-lems-graph";
 
     public static final String SVG_FLAG = "-svg";
@@ -140,105 +140,101 @@ public class JNeuroML
     public static final String PNG_FLAG = "-png";
 
     static String usage = "Usage: \n\n" + "    " + JNML_SCRIPT + " LEMSFile.xml\n"
-            + "           Load LEMSFile.xml using jLEMS, parse it and validate it as LEMS, and execute the model it contains\n\n" 
-            
-            + "    " + JNML_SCRIPT + " LEMSFile.xml " + NO_GUI_FLAG + "\n"
-            + "           As above, parse and execute the model and save results, but don't show GUI\n\n" 
-            
-            + "    " + JNML_SCRIPT + " LEMSFile.xml " + NO_RUN_FLAG + "\n"
-            + "           Parse the LEMS file, but don't run the simulation\n\n" 
-            
-            + "    " + JNML_SCRIPT + " " + SEARCH_PATH_FLAG + " directory1:directory2:directoryN LEMSFile.xml\n"
-            + "           Execute the LEMS file, inclusing the : separated list of directories on the search path for includes\n\n" 
-            
-            + "    " + JNML_SCRIPT + " LEMSFile.xml " + LEMS_GRAPH_FLAG + "\n"
-            + "           Load LEMSFile.xml using jLEMS, and convert it to GraphViz format\n\n"
-            
-            + "    " + JNML_SCRIPT + " LEMSFile.xml " + GRAPH_FLAG + "\n"
-            + "           Alias for -lems-graph"
-            + "           Load LEMSFile.xml using jLEMS, and convert it to GraphViz format\n\n"
+            + "           Load LEMSFile.xml using jLEMS, parse it and validate it as LEMS, and execute the model it contains\n\n"
 
-            + "    " + JNML_SCRIPT + " LEMSFile.xml " + NEURON_EXPORT_FLAG + " [" + NO_GUI_FLAG + "] [" + RUN_FLAG+ "] ["+OUTPUT_DIR_FLAG+" dir]\n" 
-            + "           Load LEMSFile.xml using jLEMS, and convert it to NEURON format, OR load ModelFile.nml and generate hoc and mod files for cells, channels, synapses \n" 
-            + "             " + NO_GUI_FLAG+ "       Do not generate graphical elements in NEURON, just run, save data and quit (if input file is LEMS file)\n" 
-            + "             " + RUN_FLAG + "         Compile NMODL files and run the main NEURON Python file (only with LEMS file)\n" 
-            + "             " + NEURON_COMPILE_FLAG + "     Compile NMODL files, but don't run (Linux only currently)\n" 
-            + "             " + OUTPUT_DIR_FLAG + "   Generate NEURON files in another directory, dir\n\n" 
-            
+            + "    " + JNML_SCRIPT + " LEMSFile.xml " + NO_GUI_FLAG + "\n"
+            + "           As above, parse and execute the model and save results, but don't show GUI\n\n"
+
+            + "    " + JNML_SCRIPT + " LEMSFile.xml " + NO_RUN_FLAG + "\n"
+            + "           Parse the LEMS file, but don't run the simulation\n\n"
+
+            + "    " + JNML_SCRIPT + " " + SEARCH_PATH_FLAG + " directory1:directory2:directoryN LEMSFile.xml\n"
+            + "           Execute the LEMS file, inclusing the : separated list of directories on the search path for includes\n\n"
+
+            + "    " + JNML_SCRIPT + " LEMSFile.xml " + LEMS_GRAPH_FLAG + "\n"
+            + "           Load LEMSFile.xml using jLEMS, and convert it to GraphViz format (note, previously this option was: "+OLD_GRAPH_FLAG+")\n\n"
+
+            + "    " + JNML_SCRIPT + " LEMSFile.xml " + NEURON_EXPORT_FLAG + " [" + NO_GUI_FLAG + "] [" + RUN_FLAG+ "] ["+OUTPUT_DIR_FLAG+" dir]\n"
+            + "           Load LEMSFile.xml using jLEMS, and convert it to NEURON format, OR load ModelFile.nml and generate hoc and mod files for cells, channels, synapses \n"
+            + "             " + NO_GUI_FLAG+ "       Do not generate graphical elements in NEURON, just run, save data and quit (if input file is LEMS file)\n"
+            + "             " + RUN_FLAG + "         Compile NMODL files and run the main NEURON Python file (only with LEMS file)\n"
+            + "             " + NEURON_COMPILE_FLAG + "     Compile NMODL files, but don't run (Linux only currently)\n"
+            + "             " + OUTPUT_DIR_FLAG + "   Generate NEURON files in another directory, dir\n\n"
+
             + "    " + JNML_SCRIPT + " LEMSFile.xml " + NETPYNE_EXPORT_FLAG + "\n"
-            + "           Load LEMSFile.xml using jLEMS, and convert it to NetPyNE format\n" 
-            + "             " + RUN_FLAG + "         Compile NMODL files and run the main NEURON Python file\n\n" 
-            
+            + "           Load LEMSFile.xml using jLEMS, and convert it to NetPyNE format\n"
+            + "             " + RUN_FLAG + "         Compile NMODL files and run the main NEURON Python file\n\n"
+
             + "    " + JNML_SCRIPT + " LEMSFile.xml " + BRIAN_EXPORT_FLAG + "\n"
-            + "           Load LEMSFile.xml using jLEMS, and convert it to Brian v1 format (*EXPERIMENTAL - single components only*)\n\n" 
-            
+            + "           Load LEMSFile.xml using jLEMS, and convert it to Brian v1 format (*EXPERIMENTAL - single components only*)\n\n"
+
             + "    " + JNML_SCRIPT + " LEMSFile.xml " + BRIAN2_EXPORT_FLAG + "\n"
-            + "           Load LEMSFile.xml using jLEMS, and convert it to Brian v2 format (*EXPERIMENTAL - single components only*)\n\n" 
-            
+            + "           Load LEMSFile.xml using jLEMS, and convert it to Brian v2 format (*EXPERIMENTAL - single components only*)\n\n"
+
             + "    " + JNML_SCRIPT + " LEMSFile.xml " + MOOSE_EXPORT_FLAG + "\n"
-            + "           Load LEMSFile.xml using jLEMS, and convert it to MOOSE format (**EXPERIMENTAL**)\n\n" 
-            
-            + "    " + JNML_SCRIPT + " NMLFile.nml " + SVG_FLAG + "\n" 
+            + "           Load LEMSFile.xml using jLEMS, and convert it to MOOSE format (**EXPERIMENTAL**)\n\n"
+
+            + "    " + JNML_SCRIPT + " NMLFile.nml " + SVG_FLAG + "\n"
             + "           Load NMLFile.nml and convert cells & networks to SVG image format \n\n"
-            
-            + "    " + JNML_SCRIPT + " NMLFile.nml " + PNG_FLAG + "\n" 
+
+            + "    " + JNML_SCRIPT + " NMLFile.nml " + PNG_FLAG + "\n"
             + "           Load NMLFile.nml and convert cells & networks to PNG image format \n\n"
-            
+
             + "    " + JNML_SCRIPT + " LEMSFile.xml " + DLEMS_EXPORT_FLAG + "\n"
-            + "           Load LEMSFile.xml using jLEMS, and convert it to dLEMS, a distilled form of LEMS in JSON (**EXPERIMENTAL - single components only**)\n\n" 
-            
-            + "    " + JNML_SCRIPT + " LEMSFile.xml " + VERTEX_EXPORT_FLAG+ "\n" 
-            + "           Load LEMSFile.xml using jLEMS, and convert it to VERTEX format (*EXPERIMENTAL*)\n\n" 
-            
-            + "    " + JNML_SCRIPT + " LEMSFile.xml " + XPP_EXPORT_FLAG + "\n" 
-            + "           Load LEMSFile.xml using jLEMS, and convert it to XPPAUT format (*EXPERIMENTAL - single components only*)\n\n" 
-            
-            + "    " + JNML_SCRIPT + " LEMSFile.xml " + DNSIM_EXPORT_FLAG + "\n" 
+            + "           Load LEMSFile.xml using jLEMS, and convert it to dLEMS, a distilled form of LEMS in JSON (**EXPERIMENTAL - single components only**)\n\n"
+
+            + "    " + JNML_SCRIPT + " LEMSFile.xml " + VERTEX_EXPORT_FLAG+ "\n"
+            + "           Load LEMSFile.xml using jLEMS, and convert it to VERTEX format (*EXPERIMENTAL*)\n\n"
+
+            + "    " + JNML_SCRIPT + " LEMSFile.xml " + XPP_EXPORT_FLAG + "\n"
+            + "           Load LEMSFile.xml using jLEMS, and convert it to XPPAUT format (*EXPERIMENTAL - single components only*)\n\n"
+
+            + "    " + JNML_SCRIPT + " LEMSFile.xml " + DNSIM_EXPORT_FLAG + "\n"
             + "           Load LEMSFile.xml using jLEMS, and convert it to DNsim format (*EXPERIMENTAL - single components only*)\n\n"
-            
-            + "    " + JNML_SCRIPT + " LEMSFile.xml " + SBML_EXPORT_FLAG + "\n" 
-            + "           Load LEMSFile.xml using jLEMS, and convert it to SBML format (**EXPERIMENTAL - single components only**)\n\n" 
-            
+
+            + "    " + JNML_SCRIPT + " LEMSFile.xml " + SBML_EXPORT_FLAG + "\n"
+            + "           Load LEMSFile.xml using jLEMS, and convert it to SBML format (**EXPERIMENTAL - single components only**)\n\n"
+
             + "    " + JNML_SCRIPT + " LEMSFile.xml " + SEDML_EXPORT_FLAG + "\n"
-            + "           Load LEMSFile.xml using jLEMS, and convert it (just the simulation run/display/save information) to SED-ML format\n\n" 
-            
-            + "    " + JNML_SCRIPT + " LEMSFile.xml " + SBML_SEDML_EXPORT_FLAG + "\n" 
-            + "           Load LEMSFile.xml using jLEMS, and convert it to SBML format with a SED-ML file describing the experiment to run (*EXPERIMENTAL - single components only*)\n\n" 
-            
-            + "    " + JNML_SCRIPT + " LEMSFile.xml "+ MATLAB_EXPORT_FLAG + "\n" 
-            + "           Load LEMSFile.xml using jLEMS, and convert it to MATLAB format (**EXPERIMENTAL - single components only**)\n\n" 
-            
-            + "    " + JNML_SCRIPT+ " LEMSFile.xml " + CVODE_EXPORT_FLAG + "\n" 
+            + "           Load LEMSFile.xml using jLEMS, and convert it (just the simulation run/display/save information) to SED-ML format\n\n"
+
+            + "    " + JNML_SCRIPT + " LEMSFile.xml " + SBML_SEDML_EXPORT_FLAG + "\n"
+            + "           Load LEMSFile.xml using jLEMS, and convert it to SBML format with a SED-ML file describing the experiment to run (*EXPERIMENTAL - single components only*)\n\n"
+
+            + "    " + JNML_SCRIPT + " LEMSFile.xml "+ MATLAB_EXPORT_FLAG + "\n"
+            + "           Load LEMSFile.xml using jLEMS, and convert it to MATLAB format (**EXPERIMENTAL - single components only**)\n\n"
+
+            + "    " + JNML_SCRIPT+ " LEMSFile.xml " + CVODE_EXPORT_FLAG + "\n"
             + "           Load LEMSFile.xml using jLEMS, and convert it to C format using CVODE package (**EXPERIMENTAL - single components only**)\n\n"
-            
+
             + "    " + JNML_SCRIPT + " LEMSFile.xml " + NINEML_EXPORT_FLAG + "\n"
-            + "           Load LEMSFile.xml using jLEMS, and convert it to NineML format (*EXPERIMENTAL - single components only*)\n\n" 
-            
-            + "    " + JNML_SCRIPT + " LEMSFile.xml " + SPINEML_EXPORT_FLAG+ "\n" 
-            + "           Load LEMSFile.xml using jLEMS, and convert it to SpineML format (*EXPERIMENTAL - single components only*)\n\n" 
-            
-            + "    " + JNML_SCRIPT + " " + SBML_IMPORT_FLAG+ " SBMLFile.sbml duration dt\n" 
-            + "           Load SBMLFile.sbml using jSBML, and convert it to LEMS format using values for duration & dt in ms (ignoring SBML units)\n\n" 
-            
+            + "           Load LEMSFile.xml using jLEMS, and convert it to NineML format (*EXPERIMENTAL - single components only*)\n\n"
+
+            + "    " + JNML_SCRIPT + " LEMSFile.xml " + SPINEML_EXPORT_FLAG+ "\n"
+            + "           Load LEMSFile.xml using jLEMS, and convert it to SpineML format (*EXPERIMENTAL - single components only*)\n\n"
+
+            + "    " + JNML_SCRIPT + " " + SBML_IMPORT_FLAG+ " SBMLFile.sbml duration dt\n"
+            + "           Load SBMLFile.sbml using jSBML, and convert it to LEMS format using values for duration & dt in ms (ignoring SBML units)\n\n"
+
             + "    " + JNML_SCRIPT + " " + SBML_IMPORT_UNITS_FLAG + " SBMLFile.sbml duration dt\n"
             + "           Load SBMLFile.sbml using jSBML, and convert it to LEMS format using values for duration & dt in ms (attempt to extract SBML units; ensure units are valid in the SBML!)\n\n"
-            
+
             + "    " + JNML_SCRIPT+" LEMSFile.xml " + VHDL_EXPORT_FLAG + " neuronid \n" +
-              "           Load LEMSFile.xml using jLEMS, and convert it to VHDL format (**EXPERIMENTAL - point models only - single neurons only**)\n\n"   
-            
-            + "    " + JNML_SCRIPT + " " + VALIDATE_FLAG + " NMLFile.nml\n" 
-            + "           Validate NMLFile.nml against latest v2 Schema & perform a number of other tests\n\n" 
-            
-            + "    " + JNML_SCRIPT + " " + VALIDATE_V1_FLAG + " NMLFile.nml\n" + "           Validate NMLFile.nml against NeuroML v1.8.1 Schema \n\n" 
-            
-            + "    " + JNML_SCRIPT + " " + VERSION_FLAG + "\n" 
-            
-            + "    " + JNML_SCRIPT + " " + VERSION_FLAG_LONG + "\n" + "           Print information on versions of packages used\n\n" 
-            
-            + "    " + JNML_SCRIPT + " " + HELP_FLAG + "\n" 
-            
-            + "    " + JNML_SCRIPT + " " + HELP_FLAG_SHORT + "\n" 
-            
+              "           Load LEMSFile.xml using jLEMS, and convert it to VHDL format (**EXPERIMENTAL - point models only - single neurons only**)\n\n"
+
+            + "    " + JNML_SCRIPT + " " + VALIDATE_FLAG + " NMLFile.nml\n"
+            + "           Validate NMLFile.nml against latest v2 Schema & perform a number of other tests\n\n"
+
+            + "    " + JNML_SCRIPT + " " + VALIDATE_V1_FLAG + " NMLFile.nml\n" + "           Validate NMLFile.nml against NeuroML v1.8.1 Schema \n\n"
+
+            + "    " + JNML_SCRIPT + " " + VERSION_FLAG + "\n"
+
+            + "    " + JNML_SCRIPT + " " + VERSION_FLAG_LONG + "\n" + "           Print information on versions of packages used\n\n"
+
+            + "    " + JNML_SCRIPT + " " + HELP_FLAG + "\n"
+
+            + "    " + JNML_SCRIPT + " " + HELP_FLAG_SHORT + "\n"
+
             + "    " + JNML_SCRIPT + " " + HELP_FLAG_SHORT_Q + "\n" + "           Print this help information\n\n";
 
     public static void showUsage()
@@ -261,7 +257,7 @@ public class JNeuroML
         }
         return Utils.readLemsNeuroMLFile(lemsFile,includeConnectionsFromHDF5).getLems();
     }
-    
+
     private static Lems loadNmlFileAsLems(File nmlFile) throws LEMSException, NeuroMLException, IOException
     {
         if(!nmlFile.exists())
@@ -272,27 +268,27 @@ public class JNeuroML
         }
         return Utils.readNeuroMLFile(nmlFile).getLems();
     }
-    
+
     private static String generateFormatFilename(File lemsFile, Format format, String extra)
     {
         String filename = lemsFile.getName();
         return generateFormatFilename(filename, format, extra);
     }
-    
+
     private static String generateFormatFilename(String lemsFilename, Format format, String extra)
     {
         String newSuffix = (extra!=null ? extra : "") + "." + format.getExtension();
-        
+
         String filename = lemsFilename;
-        
+
         String oldSuffix = "."+Format.LEMS.getExtension();
-        
+
         if (filename.endsWith(oldSuffix)) {
             filename = filename.substring(0, filename.length() - oldSuffix.length());
         }
-        
+
         filename = filename + newSuffix;
-                
+
         return filename;
     }
 
@@ -323,13 +319,13 @@ public class JNeuroML
                     argsToUse.add(args[i]);
                 }
             }
-            
+
             args = new String[argsToUse.size()];
             args = argsToUse.toArray(args);
-            
+
             //System.out.println("args: "+args.length            );
             //System.out.println("args: "+args[0]           );
-            
+
             if(args.length == 0)
             {
                 System.err.println("Error, no arguments to " + JNML_SCRIPT);
@@ -466,7 +462,7 @@ public class JNeuroML
 
                 File lemsNmlFile = (new File(args[0])).getCanonicalFile();
                 Lems lems = null;
-                
+
                 if (lemsNmlFile.getName().endsWith("nml"))
                 {
                     lems = loadNmlFileAsLems(lemsNmlFile);
@@ -481,7 +477,7 @@ public class JNeuroML
                 File outputDir = lemsNmlFile.getParentFile();
 
                 int i  = 2;
-                while (i<args.length) 
+                while (i<args.length)
                 {
                     if (args[i].equals(NO_GUI_FLAG))
                         nogui = true;
@@ -496,13 +492,13 @@ public class JNeuroML
                     {
                         i = i+1;
                         outputDir = (new File(args[i])).getAbsoluteFile();
-                        if (!outputDir.exists()) 
+                        if (!outputDir.exists())
                         {
                             System.out.println("Cannot find dir: " + args[i] + " ("+outputDir+")");
                             System.exit(1);
                         }
                     }
-                    else 
+                    else
                     {
                         System.out.println("Unrecognised argument: " + args[i]);
                         System.exit(1);
@@ -511,7 +507,7 @@ public class JNeuroML
                 }
                 String mainNrnFilename = generateFormatFilename(lemsNmlFile, Format.NEURON, "_nrn");
                 NeuronWriter nw = new NeuronWriter(lems, outputDir, mainNrnFilename);
-                
+
                 if (lemsNmlFile.getName().endsWith("nml"))
                 {
                     nw.generateFilesForNeuroMLElements(compile);
@@ -520,14 +516,14 @@ public class JNeuroML
                 {
                     nw.generateAndRun(nogui, compile, run, false);
                 }
-                
+
             }
             else if(args[1].equals(PYNN_EXPORT_FLAG))
             {
                 File lemsFile = (new File(args[0])).getAbsoluteFile();
                 Lems lems = loadLemsFile(lemsFile);
                 String nFile = generateFormatFilename(lemsFile, Format.PYNN, "_pynn");
-                
+
                 boolean runNrn = (args.length==3 && args[2].equals(RUN_PYNN_NEURON_FLAG));
 
                 PyNNWriter pw = new PyNNWriter(lems, lemsFile.getParentFile(), nFile);
@@ -541,9 +537,9 @@ public class JNeuroML
                 boolean run = false;
                 File outputDir = lemsFile.getParentFile();
                 int np = 1;
-                
+
                 int i  = 2;
-                while (i<args.length) 
+                while (i<args.length)
                 {
                     if (args[i].equals(NO_GUI_FLAG))
                         nogui = true;
@@ -553,7 +549,7 @@ public class JNeuroML
                     {
                         i = i+1;
                         outputDir = (new File(args[i])).getAbsoluteFile();
-                        if (!outputDir.exists()) 
+                        if (!outputDir.exists())
                         {
                             System.out.println("Cannot find dir: " + args[i] + " ("+outputDir+")");
                             System.exit(1);
@@ -564,14 +560,14 @@ public class JNeuroML
                         i = i+1;
                         np = Integer.parseInt(args[i]);
                     }
-                    else 
+                    else
                     {
                         System.out.println("Unrecognised argument: " + args[i]);
                         System.exit(1);
                     }
                     i = i+1;
                 }
-                
+
                 String mainFilename = generateFormatFilename(lemsFile, Format.NETPYNE, "_netpyne");
                 NetPyNEWriter npw = new NetPyNEWriter(lems, outputDir, mainFilename);
                 npw.generateAndRun(nogui, run, np);
@@ -635,8 +631,8 @@ public class JNeuroML
                     File lemsFile = new File(args[0]);
                     Lems lems = loadLemsFile(lemsFile);
 
-                    VertexWriter vw = new VertexWriter(lems, 
-                                                       lemsFile.getParentFile(), 
+                    VertexWriter vw = new VertexWriter(lems,
+                                                       lemsFile.getParentFile(),
                                                        generateFormatFilename(lemsFile, Format.VERTEX, "_run"));
                     for(File genFile : vw.convert())
                     {
@@ -731,7 +727,7 @@ public class JNeuroML
                         System.out.println("Writing to: " + genFile.getAbsolutePath());
                     }
                 }
-                
+
                 /*
                 Needs to be updated!!
                 else if(args[1].equals(GEPPETTO_EXPORT_FLAG))
@@ -747,7 +743,7 @@ public class JNeuroML
                     for(File genFile : gw.convert())
                     {
                         System.out.println("Writing to: " + genFile.getAbsolutePath());
-                        
+
                         if (genFile.getName().indexOf("geppetto") > 0) {
                             System.out.println("\nTry running this file locally with Geppetto using:\n\n    "
                                 + "http://localhost:8080/org.geppetto.frontend/?sim=file://" + genFile + "\n");
@@ -773,8 +769,8 @@ public class JNeuroML
                     File lemsFile = new File(args[0]);
                     Lems lems = loadLemsFile(lemsFile);
 
-                    CellMLWriter cellmlw = new CellMLWriter(lems, 
-                                                            lemsFile.getParentFile(), 
+                    CellMLWriter cellmlw = new CellMLWriter(lems,
+                                                            lemsFile.getParentFile(),
                                                             generateFormatFilename(lemsFile, Format.CELLML, null));
                     for(File genFile : cellmlw.convert())
                     {
@@ -880,8 +876,8 @@ public class JNeuroML
                     {
                         System.out.println("Writing to: " + genFile.getAbsolutePath());
                     }
-                }  
-                else if(args[1].equals(GRAPH_FLAG) || args[1].equals(LEMS_GRAPH_FLAG))
+                }
+                else if(args[1].equals(OLD_GRAPH_FLAG) || args[1].equals(LEMS_GRAPH_FLAG))
                 {
                     File lemsFile = new File(args[0]);
                     Lems lems = loadLemsFile(lemsFile);
@@ -940,10 +936,10 @@ public class JNeuroML
                     String pngFileName = nmlFile.getName().replaceAll("." + Format.NEUROML2.getExtension(), "." + Format.PNG.getExtension());
                     File pngFile = new File(nmlFile.getParentFile(), pngFileName);
                     SVGWriter svgw = new SVGWriter(nmlDocument, nmlFile.getParentFile(), pngFileName);
-                    
+
                     svgw.convertToPng(pngFile);
                     System.out.println("Writing to: " + pngFile.getAbsolutePath());
-                    
+
                 }
                 else
                 {
@@ -959,13 +955,13 @@ public class JNeuroML
 
 					File lemsFile = new File(args[0]);
 					Lems lems = loadLemsFile(lemsFile);
-					 
+
 					VHDLWriter vw = new VHDLWriter(lems);
-					
+
 					Map<String,String> componentScripts = vw.getNeuronModelScripts(args[2],false);
 					//String testbenchScript = vw.getSimulationScript(ScriptType.TESTBENCH, args[2], false);
 					String prjScript = vw.getPrjFile(componentScripts.keySet());
-					
+
 					for (Map.Entry<String, String> entry : componentScripts.entrySet()) {
 						String key = entry.getKey();
 						String val = entry.getValue();
@@ -973,14 +969,14 @@ public class JNeuroML
 						FileUtil.writeStringToFile(val, vwFile);
 						System.out.println("Writing to: "+vwFile.getAbsolutePath());
 					}
-					
+
 					/*File vwFile = new File(lemsFile.getParentFile(), "/testbench.vhdl");
 					FileUtil.writeStringToFile(testbenchScript, vwFile);
 					System.out.println("Writing to: "+vwFile.getAbsolutePath());*/
 					File vwFile = new File(lemsFile.getParentFile(), "/testbench.prj");
 					FileUtil.writeStringToFile(prjScript, vwFile);
 					System.out.println("Writing to: "+vwFile.getAbsolutePath());
-				
+
                 }
             }
             else if(args.length == 4)

--- a/src/main/java/org/neuroml/JNeuroML.java
+++ b/src/main/java/org/neuroml/JNeuroML.java
@@ -133,6 +133,7 @@ public class JNeuroML
     public static final String SBML_SEDML_EXPORT_FLAG = "-sbml-sedml";
 
     public static final String GRAPH_FLAG = "-graph";
+    public static final String LEMS_GRAPH_FLAG = "-lems-graph";
 
     public static final String SVG_FLAG = "-svg";
 
@@ -150,9 +151,13 @@ public class JNeuroML
             + "    " + JNML_SCRIPT + " " + SEARCH_PATH_FLAG + " directory1:directory2:directoryN LEMSFile.xml\n"
             + "           Execute the LEMS file, inclusing the : separated list of directories on the search path for includes\n\n" 
             
-            + "    " + JNML_SCRIPT + " LEMSFile.xml " + GRAPH_FLAG + "\n"
-            + "           Load LEMSFile.xml using jLEMS, and convert it to GraphViz format\n\n" 
+            + "    " + JNML_SCRIPT + " LEMSFile.xml " + LEMS_GRAPH_FLAG + "\n"
+            + "           Load LEMSFile.xml using jLEMS, and convert it to GraphViz format\n\n"
             
+            + "    " + JNML_SCRIPT + " LEMSFile.xml " + GRAPH_FLAG + "\n"
+            + "           Alias for -lems-graph"
+            + "           Load LEMSFile.xml using jLEMS, and convert it to GraphViz format\n\n"
+
             + "    " + JNML_SCRIPT + " LEMSFile.xml " + NEURON_EXPORT_FLAG + " [" + NO_GUI_FLAG + "] [" + RUN_FLAG+ "] ["+OUTPUT_DIR_FLAG+" dir]\n" 
             + "           Load LEMSFile.xml using jLEMS, and convert it to NEURON format, OR load ModelFile.nml and generate hoc and mod files for cells, channels, synapses \n" 
             + "             " + NO_GUI_FLAG+ "       Do not generate graphical elements in NEURON, just run, save data and quit (if input file is LEMS file)\n" 
@@ -876,7 +881,7 @@ public class JNeuroML
                         System.out.println("Writing to: " + genFile.getAbsolutePath());
                     }
                 }  
-                else if(args[1].equals(GRAPH_FLAG))
+                else if(args[1].equals(GRAPH_FLAG) || args[1].equals(LEMS_GRAPH_FLAG))
                 {
                     File lemsFile = new File(args[0]);
                     Lems lems = loadLemsFile(lemsFile);


### PR DESCRIPTION
This is primarily added for clarity, to stress that this produces a
summary graph for the simulation from its LEMS description, rather than
one of the model description from the nml file (which is not implemented
here but resides in pynml).

The usage message has also been updated to note that `-graph` is an
alias of `-lems-graph`.

Fixes https://github.com/NeuroML/jNeuroML/issues/73