### PR TITLE
enh: add script to "install" jNeuroML on Linux machines

### DIFF
--- a/installers/linux-install.sh
+++ b/installers/linux-install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2021 Ankur Sinha
+# Author: Ankur Sinha <sanjay DOT ankur AT gmail DOT com>
+# File : linux-install.sh
+#
+# Install jNeuroML on Linux machines
+jNeuroMLJarDir="$(pwd)"
+
+if [ -e "jnml" ] && [ -f jNeuroML*jar-with-dependencies.jar ];
+then
+    echo "Found jar and jnml in current directory: $jNeuroMLJarDir"
+    echo "Updating ~/.bashrc to make it available in \$PATH."
+else
+    echo "ERROR: jnml or jneuroML pre-compiled JAR file not found."
+    echo "ERROR: Please run this script from the jNeuroMLJar directory that contains both jnml and the jar file."
+    exit -1
+fi
+
+# Remove previous JNML additions
+sed -i '/JNML_HOME/ d' ~/.bashrc
+
+# Export JNML_HOME so that jnml can find the JAR
+cat >> ~/.bashrc << EOF
+# JNML_HOME etc for jNeuroML
+export JNML_HOME="$jNeuroMLJarDir"
+export PATH="\$PATH:\$JNML_HOME"
+EOF
+
+echo "Done: Please log out and back in and try to run jnml in a terminal."
+exit 0

--- a/installers/linux-install.sh
+++ b/installers/linux-install.sh
@@ -7,6 +7,16 @@
 # Install jNeuroML on Linux machines
 jNeuroMLJarDir="$(pwd)"
 
+if command -v java &> /dev/null
+then
+    echo "Found java installation:"
+    java -version
+else
+    echo "Could not find 'java' command."
+    echo "Please ensure that a Java Runtime Environment is installed on your system and that the 'java' command is usable in the terminal"
+    exit -1
+fi
+
 if [ -e "jnml" ] && [ -f jNeuroML*jar-with-dependencies.jar ];
 then
     echo "Found jar and jnml in current directory: $jNeuroMLJarDir"


### PR DESCRIPTION
It's like a makefile, but I didn't want to use make in case it wasn't installed on the system (like in containers). This just adds the required bits to the ~/.bashrc file, which should be the most common use case. For folks using other shells should be advanced enough to tweak things themselves?

Tested this out on my Fedora machine. Don't see anything that should prevent it from working on other distributions either. Not a clue about how things work on Macs, I'm afraid.

It'll be good to include this in the jar too, so our documentation can say: "download the zip, extract, run this script."